### PR TITLE
Rename a field in two test exceptions.

### DIFF
--- a/packages/thrift-server-core/src/tests/thrift/common.thrift
+++ b/packages/thrift-server-core/src/tests/thrift/common.thrift
@@ -19,7 +19,7 @@ typedef shared.SHARED_INT COMMON_INT
 
 exception AuthException {
   1: i32 code
-  2: string message
+  2: string msg
 }
 
 struct Metadata {

--- a/packages/thrift-server-core/src/tests/thrift/exceptions.thrift
+++ b/packages/thrift-server-core/src/tests/thrift/exceptions.thrift
@@ -15,6 +15,6 @@ exception InvalidOperation {
 }
 
 exception InvalidResult {
-  1: string message
+  1: string msg
   2: shared.Code code
 }


### PR DESCRIPTION
I'm merging a small change that I made in our mdoliner-st/Add_a_StructLike_class_that_extends_Error branch into our all_states_title_changes branch.

----

When using the new version of thrift-typescript where exceptions derive from `Error`, it's problematic to shadow `Error`'s `message` field. In this case the problem is that our message was optional and `Error`'s message is required, but I think it's good practice to avoid reusing `message` altogether.

Before this change the `prettier --write 'src/**/*.ts'` command was showing this error:
```
src/tests/generated/common/AuthException.ts:81:12 - error TS2416: Property 'message' in type 'AuthException' is not assignable to the same property in base type 'ErrorStructLike'.
  Type 'string | undefined' is not assignable to type 'string'.
    Type 'undefined' is not assignable to type 'string'.

81     public message?: string;
              ~~~~~~~

src/tests/generated/exceptions/InvalidResult.ts:81:12 - error TS2416: Property 'message' in type 'InvalidResult' is not assignable to the same property in base type 'ErrorStructLike'.
  Type 'string | undefined' is not assignable to type 'string'.
    Type 'undefined' is not assignable to type 'string'.

81     public message?: string;
              ~~~~~~~

Found 4 errors.
```